### PR TITLE
Implement click-and-drag color interaction on grid squares

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,6 +9,7 @@
 <body>
   <div id="title-container">
     <h1 id="main-title">Interactive Grid Sketchpad</h1>
+    <h3 id="instructions">Click and Drag the Squares to start coloring! Hold the mouse to color a trail of squares.</h3>
   </div>
   <div id="main-container">
     <div id="container"></div>

--- a/script.js
+++ b/script.js
@@ -2,6 +2,8 @@ const gridContainer = document.querySelector('#container');
 const resetButton = document.querySelector('#reset-button');
 const changeGridSizeButton = document.querySelector('#change-size-button');
 
+let isMousePressed;
+
 function generateGrid(sizeofOneSide = 16){
 
   const amountOfSquares = sizeofOneSide * sizeofOneSide;
@@ -69,12 +71,32 @@ document.addEventListener('DOMContentLoaded', () => {
   generateGrid();
 });
 
-// Add event listener to the container to listen for mouseover movements on the squares
-gridContainer.addEventListener('mouseover', (e) => {
-  if(e.target.classList.contains('square') && e.target.style.backgroundColor === ''){
-    e.target.style.backgroundColor = rgbGenerator();
+// When the user clicks the mouse and holds it will start coloring.
+gridContainer.addEventListener('mousedown', (e) => {
+  if(e.button === 0){
+    e.preventDefault();
+    isMousePressed = true;
+    if(e.target.classList.contains('square') && e.target.style.backgroundColor === ''){
+      e.target.style.backgroundColor = rgbGenerator();
+    }
   }
 })
+
+// Add event listener to the container to listen for mouseover movements on the squares
+gridContainer.addEventListener('mouseover', (e) => {
+  if(isMousePressed){
+    if(e.target.classList.contains('square') && e.target.style.backgroundColor === ''){
+      e.target.style.backgroundColor = rgbGenerator();
+    }
+  }
+})
+
+// Ensure that when the user releases the mouse button, it will stop coloring squares. 
+// Even if released outside grid.
+document.addEventListener('mouseup', (e) => {
+  isMousePressed = false;
+})
+
 // Event listener for reset button, to reset all square colors
 resetButton.addEventListener('click', (e) => {
   resetGridColor();

--- a/style.css
+++ b/style.css
@@ -6,12 +6,14 @@
 
 #title-container {
   display: flex;
-  justify-content: center;
+  flex-direction: column;
+  align-items: center;
   margin: 20px auto;
+  gap: 10px;
 }
 
-#main-title {
-  font-family:'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+#main-title, #instructions {
+  font-family:'Trebuchet MS', 'Lucida Sans Unicode', 'Lucida Grande', 'Lucida Sans', Arial, sans-serif;
   color: black;
 }
 


### PR DESCRIPTION
This pull request introduces the ability for users to click and drag across the grid squares to color them. 

Changes:
- Added mouse event listeners (mousedown and mouseup) to allow for continuous coloring while holding the mouse button.
- Prevented default drag behavior to avoid unwanted browser cursor behavior when interacting with the grid.
- Fixed issue where clicking and dragging over already colored squares resulted in unusual cursor behavior.

With these changes, the user can now click and drag across squares to leave a trail of colors, providing a more interactive experience with the grid.